### PR TITLE
update actions; remove warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,9 +10,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Node v12
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3.5.1
       with:
         node-version: 12
     - run: npm run test

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,8 +8,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3.5.1
         with:
           node-version: 12
       - uses: JS-DevTools/npm-publish@v1


### PR DESCRIPTION
### DESCRIPTION
https://belmonttechinc.atlassian.net/browse/BEL-193379
update actions; remove warnings

### TESTING
`ci.yaml` workflow is currently in a failing state.

### WIP
waiting for update to `JS-DevTools/npm-publish` to update workflow `npm-publish.yaml`.
[Deprecation warning for 'set-output' 67](https://github.com/JS-DevTools/npm-publish/issues/67)
[Upgrade Action to use node 16 instead of node 12](https://github.com/JS-DevTools/npm-publish/issues/61)
